### PR TITLE
Fix Teleportation bugs

### DIFF
--- a/ASLPortal/Assets/Portal/Scripts/Portal.cs
+++ b/ASLPortal/Assets/Portal/Scripts/Portal.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -26,12 +27,11 @@ public class Portal : MonoBehaviour
         userCamera = user.GetComponent<PlayerController>().userCamera;
 
         //set up the copy camera
-        if(copyCamera == null)
+        if (copyCamera == null)
             copyCamera = Instantiate(copyCameraPrefab, transform).GetComponent<Camera>();
 
         if (copyCamera.targetTexture != null) copyCamera.targetTexture.Release();
         copyCamera.targetTexture = new RenderTexture(Screen.width, Screen.height, 24);
-
 
         //Set up the material to reference the copy camera's rendertexture
         Material camMat = new Material(copyCamMat);
@@ -94,7 +94,7 @@ public class Portal : MonoBehaviour
             Vector3 objectOffset = m.MultiplyPoint(userCamera.transform.position);
 
             //Vector3 objectOffset = go.transform.position - transform.position;
-            bool playerInFront = Vector3.Dot(transform.forward, objectOffset) < 0.0f;
+            bool playerInFront = objectOffset.z < 0.0f;
 
             //is object moving towards the portal
             Vector3 objVelocity = go.GetComponent<Rigidbody>().velocity;
@@ -103,7 +103,7 @@ public class Portal : MonoBehaviour
             //is object in front of the portal
             if (playerInFront)
             {
-                if (movingTowards)
+                if (movingTowards || objVelocity == Vector3.zero)
                 {
                     TeleportEnter(go);
                 }
@@ -158,4 +158,22 @@ public class Portal : MonoBehaviour
         go.GetComponent<Rigidbody>().velocity = m.MultiplyVector(relativeVelocity);
     }
 
+    public void Close()
+    {
+        // Destroy copy cameras
+        if (copyCamera != null)
+        {
+            Destroy(copyCamera.gameObject);
+            copyCamera = null;
+        }
+        if (destinationPortal.copyCamera != null)
+        {
+            Destroy(destinationPortal.copyCamera.gameObject);
+            destinationPortal.copyCamera = null;
+        }
+
+        // Close destination portal
+        destinationPortal.destinationPortal = null;
+        destinationPortal = null;
+    }
 }

--- a/ASLPortal/Assets/Portal/Scripts/PortalManager.cs
+++ b/ASLPortal/Assets/Portal/Scripts/PortalManager.cs
@@ -184,8 +184,15 @@ public class PortalManager : MonoBehaviour
         {
             if (IsIDRegistered(sourceID) && IsIDRegistered(destinationID))
             {
+                if (portalSet[sourceID].destinationPortal != null)
+                    UnlinkPortal(sourceID);
+
+                if (portalSet[destinationID].destinationPortal != null)
+                    UnlinkPortal(destinationID);
+
                 portalSet[sourceID].Initialize(portalSet[destinationID], player);
                 portalSet[destinationID].Initialize(portalSet[sourceID], player);
+
                 return true;
             }
             else
@@ -198,8 +205,27 @@ public class PortalManager : MonoBehaviour
 
     private bool UnlinkPortal(int sourceID)
     {
-        //ignore for now
-        return false;
+        if (!player)
+        {
+            Debug.LogError("Cannot Unlink Portal! No player object available");
+            return false;
+        }
+        else
+        {
+            if (IsIDRegistered(sourceID))
+            {
+                if (portalSet[sourceID].destinationPortal != null)
+                {
+                    portalSet[sourceID].Close();
+                }
+                return true;
+            }
+            else
+            {
+                Debug.Log("Cannot Unlink Portal! Source not registered");
+                return false;
+            }
+        }
     }
 
     #region EVENT_PROCESSING

--- a/ASLPortal/Assets/PortalSelector.cs
+++ b/ASLPortal/Assets/PortalSelector.cs
@@ -32,6 +32,7 @@ public class PortalSelector : MonoBehaviour {
         this.sourcePortal = sourcePortal;
         sourcePortalID = this.sourcePortal.GetComponent<PhotonView>().viewID;
         destPortalID = sourcePortalID;
+        portalManager.RequestLinkPortal(sourcePortalID, destPortalID);
         //ChangeDestination();
     }
 	
@@ -45,7 +46,7 @@ public class PortalSelector : MonoBehaviour {
                 RaycastHit hit;
                 Ray ray = playerCam.ScreenPointToRay(Input.mousePosition);
                 Physics.Raycast(ray, out hit, 100f);
-                if (hit.collider.gameObject == button)
+                if (hit.collider != null && hit.collider.gameObject == button)
                 {
                     Debug.Log("Ray hit button!");
                     ChangeDestination();


### PR DESCRIPTION
Teleportation failure should no longer happen. Implemented the unlinking
and closing of portals. This fixes old portal displays (now black). It
gets rid of unused copy cameras. Old connections no longer held.